### PR TITLE
use @NotNull annotation on JsonNullable object declarations to avoid …

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -1,6 +1,5 @@
 package com.cjbooms.fabrikt.generators
 
-import com.cjbooms.fabrikt.generators.PropertyUtils.isNullable
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.PropertyInfo
@@ -184,6 +183,8 @@ object PropertyUtils {
 
     fun PropertyInfo.isNullable(isMergePatch: Boolean = false) = when (this) {
         is PropertyInfo.Field -> !this.isMandatory(isMergePatch)
+        is PropertyInfo.ObjectInlinedField -> !this.isMandatory(isMergePatch)
+        is PropertyInfo.ObjectRefField -> !this.isMandatory(isMergePatch)
         else -> !isRequired
     }
 
@@ -191,6 +192,14 @@ object PropertyUtils {
       (isMergePatch && !schema.isNullable)
             || (!isMergePatch && (isRequired && !schema.isNullable))
             || (!isMergePatch && (!isRequired && schema.default != null))
+
+    private fun PropertyInfo.ObjectInlinedField.isMandatory(isMergePatch: Boolean = false) =
+        (isMergePatch && !schema.isNullable)
+                || (!isMergePatch && (isRequired && !schema.isNullable))
+
+    private fun PropertyInfo.ObjectRefField.isMandatory(isMergePatch: Boolean = false) =
+        (isMergePatch && !schema.isNullable)
+                || (!isMergePatch && (isRequired && !schema.isNullable))
 
 
     /**

--- a/src/test/resources/examples/jsonMergePatch/models/Models.kt
+++ b/src/test/resources/examples/jsonMergePatch/models/Models.kt
@@ -43,6 +43,7 @@ public data class InnerOnlyMergePatchRef(
 public data class NestedMergePatchInline(
     @param:JsonProperty("inner")
     @get:JsonProperty("inner")
+    @get:NotNull
     @get:Valid
     public val `inner`: JsonNullable<NestedMergePatchInlineInner> = JsonNullable.undefined(),
 )
@@ -57,6 +58,7 @@ public data class NestedMergePatchInlineInner(
 public data class NestedMergePatchRef(
     @param:JsonProperty("inner")
     @get:JsonProperty("inner")
+    @get:NotNull
     @get:Valid
     public val `inner`: JsonNullable<InnerMergePatch> = JsonNullable.undefined(),
 )
@@ -84,6 +86,7 @@ public data class NoMergePatchRef(
 public data class TopLevelLevelMergePatchInline(
     @param:JsonProperty("inner")
     @get:JsonProperty("inner")
+    @get:NotNull
     @get:Valid
     public val `inner`: JsonNullable<TopLevelLevelMergePatchInlineInner> = JsonNullable.undefined(),
 )
@@ -97,6 +100,7 @@ public data class TopLevelLevelMergePatchInlineInner(
 public data class TopLevelLevelMergePatchRef(
     @param:JsonProperty("inner")
     @get:JsonProperty("inner")
+    @get:NotNull
     @get:Valid
     public val `inner`: JsonNullable<InnerNotMergePatch> = JsonNullable.undefined(),
 )

--- a/src/test/resources/examples/nullability/api.yaml
+++ b/src/test/resources/examples/nullability/api.yaml
@@ -41,3 +41,15 @@ components:
         nullable-required:
           type: string
           nullable: true
+    PropertyNullabilityCheck:
+      type: object
+      x-json-merge-patch: true
+      properties:
+        settings:
+          type: object
+          nullable: false
+          required:
+            - enabled
+          properties:
+            enabled:
+              type: boolean

--- a/src/test/resources/examples/nullability/models/Models.kt
+++ b/src/test/resources/examples/nullability/models/Models.kt
@@ -2,7 +2,9 @@ package examples.nullability.models
 
 import com.fasterxml.jackson.`annotation`.JsonProperty
 import org.openapitools.jackson.nullable.JsonNullable
+import javax.validation.Valid
 import javax.validation.constraints.NotNull
+import kotlin.Boolean
 import kotlin.String
 
 public data class MergePatchNullabilityCheck(
@@ -36,4 +38,19 @@ public data class NullabilityCheck(
     @param:JsonProperty("nullable-required")
     @get:JsonProperty("nullable-required")
     public val nullableRequired: String?,
+)
+
+public data class PropertyNullabilityCheck(
+    @param:JsonProperty("settings")
+    @get:JsonProperty("settings")
+    @get:NotNull
+    @get:Valid
+    public val settings: JsonNullable<PropertyNullabilityCheckSettings> = JsonNullable.undefined(),
+)
+
+public data class PropertyNullabilityCheckSettings(
+    @param:JsonProperty("enabled")
+    @get:JsonProperty("enabled")
+    @get:NotNull
+    public val enabled: Boolean,
 )


### PR DESCRIPTION
…NPEs at Runtime. Validation of Jakarta does not apply if @NotNull is missing and it seems that the mix of Java and Kotlin somehow destroys the Kotlin Nullsafety.